### PR TITLE
Refine Gemini prompt for store associate tone

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -9,6 +9,7 @@ import { AssetsModule } from './assets/assets.module';
 import { DatabaseStartupService } from './database/database-startup.service';
 import { LocationEntity } from './entities/location.entity';
 import { AssetEntity } from './entities/asset.entity';
+import { ChatModule } from './chat/chat.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { AssetEntity } from './entities/asset.entity';
     ScheduleModule.forRoot(),
     RepositoryModule,
     AssetsModule,
+    ChatModule,
   ],
   controllers: [AppController],
   providers: [AppService, DatabaseStartupService],

--- a/src/chat/chat-prompt.util.spec.ts
+++ b/src/chat/chat-prompt.util.spec.ts
@@ -1,0 +1,42 @@
+import { buildFashionAdvisorInstruction, buildGeminiContents } from './chat-prompt.util';
+import { FASHION_PRODUCTS } from './data/fashion-products.data';
+
+describe('chat prompt utils', () => {
+  it('buildFashionAdvisorInstruction should include catalog details and store voice', () => {
+    const prompt = buildFashionAdvisorInstruction(FASHION_PRODUCTS);
+
+    expect(prompt).toContain('Danh mục sản phẩm hiện có');
+    expect(prompt).toContain('nhân viên tư vấn bán hàng của cửa hàng thời trang Glory Boutique');
+    expect(prompt).toContain('Bắt đầu mỗi phản hồi bằng lời chào thân thiện');
+    expect(prompt).toContain('Giọng điệu: dùng đại từ "mình" khi xưng');
+    for (const product of FASHION_PRODUCTS) {
+      expect(prompt).toContain(product.name);
+      expect(prompt).toContain(product.priceRange);
+    }
+  });
+
+  it('buildGeminiContents should map history and include latest message', () => {
+    const contents = buildGeminiContents('Mình cần tư vấn đầm dự tiệc', [
+      { role: 'user', content: 'Xin chào shop' },
+      { role: 'assistant', content: 'Chào bạn, mình có thể hỗ trợ gì?' },
+    ]);
+
+    expect(contents).toHaveLength(3);
+    expect(contents[0]).toEqual({
+      role: 'user',
+      parts: [{ text: 'Xin chào shop' }],
+    });
+    expect(contents[1]).toEqual({
+      role: 'model',
+      parts: [{ text: 'Chào bạn, mình có thể hỗ trợ gì?' }],
+    });
+    expect(contents[2]).toEqual({
+      role: 'user',
+      parts: [{ text: 'Mình cần tư vấn đầm dự tiệc' }],
+    });
+  });
+
+  it('buildGeminiContents should throw for empty message', () => {
+    expect(() => buildGeminiContents('   ', [])).toThrow('Message must not be empty');
+  });
+});

--- a/src/chat/chat-prompt.util.ts
+++ b/src/chat/chat-prompt.util.ts
@@ -1,0 +1,85 @@
+import { ChatHistoryMessage, GeminiContent } from './interfaces/chat.interface';
+import { FashionProduct } from './data/fashion-products.data';
+
+const ROLE_MAPPING = {
+  user: 'user',
+  assistant: 'model',
+} as const;
+
+export function buildFashionAdvisorInstruction(products: FashionProduct[]): string {
+  const intro = [
+    'Bạn là nhân viên tư vấn bán hàng của cửa hàng thời trang Glory Boutique.',
+    'Hãy tự giới thiệu là nhân viên cửa hàng và giao tiếp như một stylist chuyên nghiệp luôn đồng hành cùng khách.',
+    'Nhiệm vụ của bạn là gợi ý trang phục, phụ kiện và cách phối đồ dựa trên sở thích, dáng người, hoàn cảnh sử dụng của khách hàng.',
+    'Luôn tư vấn bằng tiếng Việt tự nhiên, nhiệt tình và tạo cảm giác được chăm sóc tận tâm như tại showroom.',
+  ].join(' ');
+
+  const catalog = products
+    .map((product, index) => {
+      const lines = [
+        `${index + 1}. ${product.name} [${product.category}] - giá: ${product.priceRange}.`,
+        `   - Mô tả: ${product.description}`,
+        `   - Màu sắc: ${product.colors.join(', ')}`,
+        `   - Size: ${product.sizes.join(', ')}`,
+        `   - Chất liệu: ${product.materials.join(', ')}`,
+        `   - Dịp phù hợp: ${product.occasions.join(', ')}`,
+        `   - Điểm nổi bật: ${product.highlights.join('; ')}`,
+        `   - Tồn kho: ${product.inventoryStatus}`,
+      ];
+      return lines.join('\n');
+    })
+    .join('\n');
+
+  const guidance = [
+    'Nguyên tắc tư vấn:',
+    '1. Bắt đầu mỗi phản hồi bằng lời chào thân thiện và nhắc bạn là nhân viên Glory Boutique sẵn sàng hỗ trợ.',
+    '2. Luôn xác nhận lại thông tin khách cung cấp và đề xuất thêm câu hỏi để hiểu rõ nhu cầu.',
+    '3. Đưa ra tối đa 3 gợi ý phù hợp cùng lý do rõ ràng (phù hợp màu da, dáng người, hoàn cảnh...).',
+    '4. Có thể gợi ý phối hợp nhiều sản phẩm trong danh mục để tạo outfit hoàn chỉnh.',
+    '5. Nếu sản phẩm khách yêu cầu hết hàng, đề xuất phương án thay thế với ưu điểm tương tự.',
+    '6. Luôn nhắc khách kiểm tra size và chính sách đổi trả của cửa hàng.',
+    '7. Giọng điệu: dùng đại từ "mình" khi xưng, gọi khách là "bạn", giữ thái độ nhiệt tình, chân thành như đang tư vấn trực tiếp tại cửa hàng.',
+  ].join('\n');
+
+  return `${intro}\n\nDanh mục sản phẩm hiện có:\n${catalog}\n\n${guidance}`;
+}
+
+export function buildGeminiContents(
+  message: string,
+  history: ChatHistoryMessage[] = [],
+): GeminiContent[] {
+  const contents: GeminiContent[] = [];
+
+  for (const item of history) {
+    if (!item || typeof item.content !== 'string') {
+      continue;
+    }
+
+    const cleaned = item.content.trim();
+    if (!cleaned) {
+      continue;
+    }
+
+    const mappedRole = ROLE_MAPPING[item.role];
+    if (!mappedRole) {
+      continue;
+    }
+
+    contents.push({
+      role: mappedRole,
+      parts: [{ text: cleaned }],
+    });
+  }
+
+  const latest = message.trim();
+  if (!latest) {
+    throw new Error('Message must not be empty');
+  }
+
+  contents.push({
+    role: 'user',
+    parts: [{ text: latest }],
+  });
+
+  return contents;
+}

--- a/src/chat/chat.controller.ts
+++ b/src/chat/chat.controller.ts
@@ -1,0 +1,54 @@
+import { Body, Controller, Post, BadRequestException } from '@nestjs/common';
+import { ChatService } from './chat.service';
+import { ChatHistoryMessage, ChatResponse } from './interfaces/chat.interface';
+
+interface ChatRequestBody {
+  message?: unknown;
+  history?: unknown;
+}
+
+@Controller('chat')
+export class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+
+  @Post('fashion-consultant')
+  public async consultFashion(@Body() body: ChatRequestBody): Promise<ChatResponse> {
+    if (!body || typeof body.message !== 'string' || !body.message.trim()) {
+      throw new BadRequestException('message is required');
+    }
+
+    let history: ChatHistoryMessage[] | undefined;
+    if (body.history !== undefined) {
+      if (!Array.isArray(body.history)) {
+        throw new BadRequestException('history must be an array');
+      }
+
+      history = body.history.map((item, index) => {
+        if (!item || typeof item !== 'object') {
+          throw new BadRequestException(`history[${index}] must be an object`);
+        }
+
+        const role = (item as Record<string, unknown>).role;
+        const content = (item as Record<string, unknown>).content;
+
+        if (role !== 'user' && role !== 'assistant') {
+          throw new BadRequestException(`history[${index}].role must be \"user\" hoặc \"assistant\"`);
+        }
+
+        if (typeof content !== 'string' || !content.trim()) {
+          throw new BadRequestException(`history[${index}].content must be a non-empty string`);
+        }
+
+        return {
+          role,
+          content,
+        };
+      });
+    }
+
+    return this.chatService.consultFashion({
+      message: body.message,
+      history,
+    });
+  }
+}

--- a/src/chat/chat.module.ts
+++ b/src/chat/chat.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { HttpModule } from '@nestjs/axios';
+import { ChatController } from './chat.controller';
+import { ChatService } from './chat.service';
+
+@Module({
+  imports: [
+    HttpModule.register({
+      timeout: 10000,
+      maxRedirects: 5,
+    }),
+  ],
+  controllers: [ChatController],
+  providers: [ChatService],
+  exports: [ChatService],
+})
+export class ChatModule {}

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -1,0 +1,133 @@
+import { Injectable, BadRequestException, InternalServerErrorException, Logger } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { ConfigService } from '@nestjs/config';
+import { AxiosError } from 'axios';
+import { firstValueFrom } from 'rxjs';
+import { ChatRequest, ChatResponse, GeminiContent } from './interfaces/chat.interface';
+import { buildFashionAdvisorInstruction, buildGeminiContents } from './chat-prompt.util';
+import { FASHION_PRODUCTS } from './data/fashion-products.data';
+
+interface GeminiGenerateContentResponse {
+  candidates?: Array<{
+    content?: {
+      parts?: Array<{ text?: string }>;
+    };
+  }>;
+  promptFeedback?: unknown;
+  usageMetadata?: unknown;
+}
+
+@Injectable()
+export class ChatService {
+  private readonly logger = new Logger(ChatService.name);
+  private readonly modelName = 'gemini-1.5-flash';
+
+  constructor(
+    private readonly httpService: HttpService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  public async consultFashion(request: ChatRequest): Promise<ChatResponse> {
+    const apiKey = this.configService.get<string>('GEMINI_API_KEY');
+    if (!apiKey) {
+      throw new BadRequestException('Gemini API key is not configured');
+    }
+
+    let contents: GeminiContent[];
+    try {
+      contents = buildGeminiContents(request.message, request.history ?? []);
+    } catch (error) {
+      throw new BadRequestException(error instanceof Error ? error.message : 'Invalid chat message');
+    }
+
+    const payload = {
+      systemInstruction: {
+        role: 'system',
+        parts: [
+          {
+            text: buildFashionAdvisorInstruction(FASHION_PRODUCTS),
+          },
+        ],
+      },
+      contents,
+      generationConfig: {
+        temperature: 0.7,
+        topP: 0.95,
+        topK: 32,
+        maxOutputTokens: 512,
+      },
+    };
+
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${this.modelName}:generateContent?key=${apiKey}`;
+
+    try {
+      const response = await firstValueFrom(
+        this.httpService.post<GeminiGenerateContentResponse>(url, payload, {
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      const reply = this.extractReplyText(response.data);
+      if (!reply) {
+        throw new InternalServerErrorException('Không nhận được phản hồi từ Gemini');
+      }
+
+      return {
+        reply,
+        model: this.modelName,
+        promptFeedback: response.data?.promptFeedback,
+        usageMetadata: response.data?.usageMetadata,
+      };
+    } catch (error) {
+      return this.handleGeminiError(error);
+    }
+  }
+
+  private extractReplyText(data?: GeminiGenerateContentResponse): string | null {
+    if (!data?.candidates || !Array.isArray(data.candidates)) {
+      return null;
+    }
+
+    for (const candidate of data.candidates) {
+      const parts = candidate?.content?.parts;
+      if (!parts || !Array.isArray(parts)) {
+        continue;
+      }
+
+      const message = parts
+        .map(part => (typeof part.text === 'string' ? part.text.trim() : ''))
+        .filter(Boolean)
+        .join('\n')
+        .trim();
+
+      if (message) {
+        return message;
+      }
+    }
+
+    return null;
+  }
+
+  private handleGeminiError(error: unknown): never {
+    if (error instanceof BadRequestException || error instanceof InternalServerErrorException) {
+      throw error;
+    }
+
+    const axiosError = error as AxiosError<{ error?: { message?: string } }>;
+    if (axiosError?.isAxiosError) {
+      const status = axiosError.response?.status ?? 500;
+      const message = axiosError.response?.data?.error?.message || axiosError.message || 'Gemini API request failed';
+
+      this.logger.error(`Gemini API error (${status}): ${message}`);
+
+      if (status >= 400 && status < 500) {
+        throw new BadRequestException(message);
+      }
+
+      throw new InternalServerErrorException('Gemini service is currently unavailable');
+    }
+
+    this.logger.error(`Unexpected error when contacting Gemini: ${error}`);
+    throw new InternalServerErrorException('Gemini service is currently unavailable');
+  }
+}

--- a/src/chat/data/fashion-products.data.ts
+++ b/src/chat/data/fashion-products.data.ts
@@ -1,0 +1,88 @@
+export interface FashionProduct {
+  id: string;
+  name: string;
+  category: string;
+  priceRange: string;
+  description: string;
+  colors: string[];
+  sizes: string[];
+  materials: string[];
+  occasions: string[];
+  highlights: string[];
+  inventoryStatus: string;
+}
+
+export const FASHION_PRODUCTS: FashionProduct[] = [
+  {
+    id: 'D001',
+    name: 'Đầm midi xếp ly Aurora',
+    category: 'Đầm dự tiệc',
+    priceRange: '1.690.000 - 1.890.000 VND',
+    description:
+      'Thiết kế cổ vuông tôn dáng với phần eo nhún và chân váy xếp ly bồng nhẹ, phù hợp cho tiệc tối và sự kiện trang trọng.',
+    colors: ['Đỏ ruby', 'Xanh navy'],
+    sizes: ['S', 'M', 'L'],
+    materials: ['Lụa satin cao cấp', 'Lót polyester thoáng khí'],
+    occasions: ['Tiệc tối', 'Sự kiện quan trọng', 'Hẹn hò'],
+    highlights: [
+      'Tạo hiệu ứng thon gọn vòng eo',
+      'Chất liệu mềm mịn, ít nhăn',
+      'Độ dài qua gối lịch sự',
+    ],
+    inventoryStatus: 'Còn đầy đủ size, màu đỏ ruby đang bán chạy',
+  },
+  {
+    id: 'O014',
+    name: 'Áo blazer dáng suông Emerald',
+    category: 'Áo khoác',
+    priceRange: '1.290.000 VND',
+    description:
+      'Blazer dáng suông hiện đại với chi tiết ve áo bản vừa và cúc kim loại. Dễ phối với quần âu, váy suông hoặc jeans.',
+    colors: ['Xanh lục bảo', 'Kem'],
+    sizes: ['XS', 'S', 'M', 'L'],
+    materials: ['Twill pha len', 'Lót thun co giãn'],
+    occasions: ['Đi làm', 'Gặp gỡ đối tác', 'Mix-and-match cuối tuần'],
+    highlights: [
+      'Form suông che khuyết điểm vai và tay',
+      'Có túi ẩn tiện lợi',
+      'Mix được phong cách smart-casual hoặc semi-formal',
+    ],
+    inventoryStatus: 'Size XS chỉ còn 2 chiếc, các size còn lại còn đủ',
+  },
+  {
+    id: 'S022',
+    name: 'Chân váy bút chì Velvet',
+    category: 'Chân váy',
+    priceRange: '890.000 VND',
+    description:
+      'Chân váy bút chì phối chất liệu nhung gân, có đường may chéo tạo hiệu ứng kéo dài chân.',
+    colors: ['Đen than', 'Nâu chocolate'],
+    sizes: ['S', 'M', 'L', 'XL'],
+    materials: ['Nhung gân nhập khẩu', 'Thun co giãn 4 chiều'],
+    occasions: ['Đi làm', 'Dạ tiệc nhẹ', 'Chụp hình lookbook'],
+    highlights: [
+      'Có lớp lót mỏng chống tĩnh điện',
+      'Đường xẻ sau tiện di chuyển',
+      'Đính nút trang trí kim loại cổ điển',
+    ],
+    inventoryStatus: 'Size XL mới về thêm hàng, các size khác bán ổn định',
+  },
+  {
+    id: 'T031',
+    name: 'Áo len cổ lọ Breeze',
+    category: 'Áo len',
+    priceRange: '720.000 VND',
+    description:
+      'Áo len cổ lọ ôm nhẹ, đan họa tiết gân nổi giúp giữ ấm nhưng vẫn thoáng. Dễ phối layer mùa thu đông.',
+    colors: ['Be nhạt', 'Xám tro', 'Hồng phấn'],
+    sizes: ['S', 'M', 'L'],
+    materials: ['Len cotton pha cashmere'],
+    occasions: ['Đi làm', 'Đi chơi cuối tuần', 'Du lịch Đà Lạt'],
+    highlights: [
+      'Co giãn 4 chiều, không gây ngứa',
+      'Thiết kế tay dài bo nhẹ tạo sự thon gọn',
+      'Có thể mặc riêng hoặc layer với blazer/áo khoác',
+    ],
+    inventoryStatus: 'Màu be bán chạy nhất, đang dự kiến nhập thêm cuối tuần',
+  },
+];

--- a/src/chat/interfaces/chat.interface.ts
+++ b/src/chat/interfaces/chat.interface.ts
@@ -1,0 +1,27 @@
+export type ChatClientRole = 'user' | 'assistant';
+
+export interface ChatHistoryMessage {
+  role: ChatClientRole;
+  content: string;
+}
+
+export interface ChatRequest {
+  message: string;
+  history?: ChatHistoryMessage[];
+}
+
+export interface ChatResponse {
+  reply: string;
+  model: string;
+  promptFeedback?: unknown;
+  usageMetadata?: unknown;
+}
+
+export interface GeminiContentPart {
+  text: string;
+}
+
+export interface GeminiContent {
+  role: 'user' | 'model';
+  parts: GeminiContentPart[];
+}


### PR DESCRIPTION
## Summary
- reinforce the Gemini fashion assistant prompt so it always speaks as a friendly Glory Boutique sales associate
- expand the prompt utility unit test to assert the new greeting and voice guidance alongside the catalog data

## Testing
- npm test -- --runInBand src/chat/chat-prompt.util.spec.ts -t "buildFashionAdvisorInstruction should include catalog details and store voice"
- npm test -- --runInBand src/chat/chat-prompt.util.spec.ts -t "buildGeminiContents should map history and include latest message"
- npm test -- --runInBand src/chat/chat-prompt.util.spec.ts -t "buildGeminiContents should throw for empty message"

------
https://chatgpt.com/codex/tasks/task_e_68c936543964832ba602b90070373de3